### PR TITLE
Use node16 instead of node12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Use node16 instead of node12
+
 ## 1.0.1 - 2022-04-16
 
 ### Changed

--- a/action.yml
+++ b/action.yml
@@ -1,7 +1,7 @@
 name: Rust Problem Matchers
 description: Setup Problem Matchers for Rust.
 runs:
-  using: node12
+  using: node16
   main: index.js
 branding:
   color: orange


### PR DESCRIPTION
Fixes the following deprecation warning that currently occurs:

> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: r7kamura/rust-problem-matchers@v1
