### PR TITLE
Print `add-matcher` command through JavaScript to avoid `bash` dependency

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,10 +1,8 @@
 name: Rust Problem Matchers
 description: Setup Problem Matchers for Rust.
 runs:
-  using: "composite"
-  steps:
-    - run: echo "::add-matcher::${{ github.action_path }}/.github/matchers.json"
-      shell: bash
+  using: "node16"
+  main: "index.js"
 branding:
   color: orange
   icon: list

--- a/index.js
+++ b/index.js
@@ -1,0 +1,2 @@
+const path = __dirname + "/.github/matchers.json"
+console.log(`::add-matcher::${path}`);


### PR DESCRIPTION
Makes the action usable on self-hosted Windows machines.
