### PR TITLE
Add note about current support status on ANSI colored output

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ jobs:
           command: test
 ```
 
+### Note
+
+This action does not currently support ANSI colored output, so do not set `term.color` or `CARGO_TERM_COLOR` to `always`.
+
 ### Screenshot
 
 ![screenshot](/images/screenshot.png)


### PR DESCRIPTION
In response to the following issue, I thought it should be explained at least about the current support status on ANSI colored output:

- https://github.com/r7kamura/rust-problem-matchers/issues/8