### PR TITLE
Use node20 instead of node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,7 +1,7 @@
 name: Rust Problem Matchers
 description: Setup Problem Matchers for Rust.
 runs:
-  using: "node16"
+  using: "node20"
   main: "index.js"
 branding:
   color: orange


### PR DESCRIPTION
Fixes the following deprecation warning that currently occurs:

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: r7kamura/rust-problem-matchers@v1.4.0. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.